### PR TITLE
[all] Refactor sound tags

### DIFF
--- a/docs/tags/define-sound.md
+++ b/docs/tags/define-sound.md
@@ -1,0 +1,13 @@
+# DefineSound
+
+```
+interface DefineSound variantof Tag(type) {
+  id: Uint(16);
+  soundType: SoundType;
+  soundSize: SoundSize;
+  soundRate: SoundRate;
+  format: AudioCodingFormat;
+  sampleCount: Uint(32);
+  data: Buffer;
+}
+```

--- a/docs/tags/do-action.md
+++ b/docs/tags/do-action.md
@@ -2,6 +2,6 @@
 
 ```
 interface DoAction variantof Tag(type) {
-  actions: avm1.Action[];
+  actions: Buffer;
 }
 ```

--- a/docs/tags/do-init-action.md
+++ b/docs/tags/do-init-action.md
@@ -2,7 +2,7 @@
 
 ```
 interface DoInitAction variantof Tag(type) {
-  spriateId: Uint(16);
-  actions: avm1.Action[];
+  spriteId: Uint(16);
+  actions: Buffer;
 }
 ```

--- a/docs/tags/sound-stream-block.md
+++ b/docs/tags/sound-stream-block.md
@@ -1,0 +1,7 @@
+# SoundStreamBlock
+
+```
+interface SoundStreamBlock variantof Tag(type) {
+  data: Buffer;
+}
+```

--- a/docs/tags/sound-stream-head.md
+++ b/docs/tags/sound-stream-head.md
@@ -1,0 +1,15 @@
+# SoundStreamHead
+
+```
+interface SoundStreamHead variantof Tag(type) {
+  playbackSoundType: SoundType;
+  playbackSoundSize: SoundSize;
+  playbackSoundRate: SoundRate;
+  streamSoundType: SoundType;
+  streamSoundSize: SoundSize;
+  streamSoundRate: SoundRate;
+  streamFormat: AudioCodingFormat;
+  sampleCount: Uint(16);
+  latencySeek: Option(Sint(16));
+}
+```

--- a/rs/src/tags.rs
+++ b/rs/src/tags.rs
@@ -240,10 +240,10 @@ pub struct DefineShape {
 #[serde(rename_all = "snake_case")]
 pub struct DefineSound {
   pub id: u16,
-  pub format: AudioCodingFormat,
-  pub sound_rate: SoundRate,
-  pub sound_size: SoundSize,
   pub sound_type: SoundType,
+  pub sound_size: SoundSize,
+  pub sound_rate: SoundRate,
+  pub format: AudioCodingFormat,
   pub sample_count: u32,
   #[serde(serialize_with = "buffer_to_hex", deserialize_with = "hex_to_buffer")]
   pub data: Vec<u8>,
@@ -386,14 +386,14 @@ pub struct SoundStreamBlock {
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub struct SoundStreamHead {
-  pub playback_sound_rate: sound::SoundRate,
-  pub playback_sound_size: sound::SoundSize,
   pub playback_sound_type: sound::SoundType,
-  pub stream_sound_compression: sound::AudioCodingFormat,
-  pub stream_sound_rate: sound::SoundRate,
-  pub stream_sound_size: sound::SoundSize,
+  pub playback_sound_size: sound::SoundSize,
+  pub playback_sound_rate: sound::SoundRate,
   pub stream_sound_type: sound::SoundType,
-  pub stream_sound_sample_count: u16,
+  pub stream_sound_size: sound::SoundSize,
+  pub stream_sound_rate: sound::SoundRate,
+  pub stream_format: sound::AudioCodingFormat,
+  pub stream_sample_count: u16,
   #[serde(skip_serializing_if = "Option::is_none")]
   pub latency_seek: Option<i16>,
 }

--- a/ts/src/lib/tags/define-sound.ts
+++ b/ts/src/lib/tags/define-sound.ts
@@ -15,10 +15,10 @@ import { $TagType, TagType } from "../tags/_type";
 export interface DefineSound extends _Tag {
   readonly type: TagType.DefineSound;
   readonly id: Uint16;
-  readonly format: AudioCodingFormat;
-  readonly soundRate: SoundRate;
-  readonly soundSize: SoundSize;
   readonly soundType: SoundType;
+  readonly soundSize: SoundSize;
+  readonly soundRate: SoundRate;
+  readonly format: AudioCodingFormat;
   readonly sampleCount: Uint32;
   readonly data: Uint8Array;
 }
@@ -27,10 +27,10 @@ export const $DefineSound: DocumentIoType<DefineSound> = new DocumentType<Define
   properties: {
     type: {type: new LiteralType({type: $TagType, value: TagType.DefineSound as TagType.DefineSound})},
     id: {type: $Uint16},
-    format: {type: $AudioCodingFormat},
-    soundRate: {type: $SoundRate},
-    soundSize: {type: $SoundSize},
     soundType: {type: $SoundType},
+    soundSize: {type: $SoundSize},
+    soundRate: {type: $SoundRate},
+    format: {type: $AudioCodingFormat},
     sampleCount: {type: $Uint32},
     data: {type: $Bytes},
   },

--- a/ts/src/lib/tags/sound-stream-head.ts
+++ b/ts/src/lib/tags/sound-stream-head.ts
@@ -13,28 +13,28 @@ import { $TagType, TagType } from "./_type";
 
 export interface SoundStreamHead extends _Tag {
   readonly type: TagType.SoundStreamHead;
-  readonly playbackSoundRate: SoundRate;
-  readonly playbackSoundSize: SoundSize;
   readonly playbackSoundType: SoundType;
-  readonly streamSoundCompression: AudioCodingFormat;
-  readonly streamSoundRate: SoundRate;
-  readonly streamSoundSize: SoundSize;
+  readonly playbackSoundSize: SoundSize;
+  readonly playbackSoundRate: SoundRate;
   readonly streamSoundType: SoundType;
-  readonly streamSoundSampleCount: Uint16;
+  readonly streamSoundSize: SoundSize;
+  readonly streamSoundRate: SoundRate;
+  readonly streamFormat: AudioCodingFormat;
+  readonly streamSampleCount: Uint16;
   readonly latencySeek?: Sint16;
 }
 
 export const $SoundStreamHead: DocumentIoType<SoundStreamHead> = new DocumentType<SoundStreamHead>({
   properties: {
     type: {type: new LiteralType({type: $TagType, value: TagType.SoundStreamHead as TagType.SoundStreamHead})},
-    playbackSoundRate: {type: $SoundRate},
-    playbackSoundSize: {type: $SoundSize},
     playbackSoundType: {type: $SoundType},
-    streamSoundCompression: {type: $AudioCodingFormat},
-    streamSoundRate: {type: $SoundRate},
-    streamSoundSize: {type: new LiteralType({type: $SoundSize, value: 16 as 16})},
+    playbackSoundSize: {type: $SoundSize},
+    playbackSoundRate: {type: $SoundRate},
     streamSoundType: {type: $SoundType},
-    streamSoundSampleCount: {type: $Uint16},
+    streamSoundSize: {type: $SoundSize},
+    streamSoundRate: {type: $SoundRate},
+    streamFormat: {type: $AudioCodingFormat},
+    streamSampleCount: {type: $Uint16},
     latencySeek: {type: $Sint16, optional: true},
   },
   changeCase: CaseStyle.SnakeCase,

--- a/ts/src/test/movie.spec.ts
+++ b/ts/src/test/movie.spec.ts
@@ -43,9 +43,11 @@ interface Sample {
 }
 
 function* getSamples(): IterableIterator<Sample> {
-  // yield {name: "blank"};
+  yield {name: "blank"};
   yield {name: "hello-world"};
   // yield {name: "homestuck-beta-1"};
+  // yield {name: "homestuck-beta-2"};
   yield {name: "morph-rotating-square"};
   yield {name: "squares"};
+  yield {name: "zombo-inrozxa"};
 }


### PR DESCRIPTION
Reorder fields and rename `streamSoundSampleCount` to `streamSampleCount` and `streamSoundCompression` to `streanFormat`.