### PR TITLE
[rs] Derive `Copy` for simple enums

### DIFF
--- a/rs/src/basic_types.rs
+++ b/rs/src/basic_types.rs
@@ -25,7 +25,7 @@ pub struct ColorTransformWithAlpha {
   pub alpha_add: i16,
 }
 
-#[derive(Serialize, Deserialize, Debug, PartialEq, Eq)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Copy, Clone)]
 #[serde(rename_all = "kebab-case")]
 pub enum LanguageCode {
   Auto,
@@ -64,7 +64,7 @@ pub struct Rect {
 }
 
 // Color point in the sRGB color space with 8-bit color depth
-#[derive(Serialize, Deserialize, Debug, PartialEq, Eq)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Copy, Clone)]
 #[serde(rename_all = "snake_case")]
 pub struct SRgb8 {
   pub r: u8,
@@ -73,7 +73,7 @@ pub struct SRgb8 {
 }
 
 // Color point with straight alpha in the sRGB color space with 8-bit color depth
-#[derive(Serialize, Deserialize, Debug, PartialEq, Eq)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Copy, Clone)]
 #[serde(rename_all = "snake_case")]
 pub struct StraightSRgba8 {
   pub r: u8,
@@ -82,7 +82,7 @@ pub struct StraightSRgba8 {
   pub a: u8,
 }
 
-#[derive(Serialize, Deserialize, Debug, PartialEq, Eq)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Copy, Clone)]
 #[serde(rename_all = "snake_case")]
 pub struct Vector2D {
   pub x: i32,

--- a/rs/src/gradient.rs
+++ b/rs/src/gradient.rs
@@ -2,7 +2,7 @@ use ::serde::{Deserialize, Serialize};
 
 use crate::basic_types::StraightSRgba8;
 
-#[derive(Serialize, Deserialize, Debug, PartialEq, Eq)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Copy, Clone)]
 #[serde(rename_all = "kebab-case")]
 pub enum GradientSpread {
   Pad,
@@ -10,7 +10,7 @@ pub enum GradientSpread {
   Repeat,
 }
 
-#[derive(Serialize, Deserialize, Debug, PartialEq, Eq)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Copy, Clone)]
 #[serde(rename_all = "kebab-case")]
 pub enum ColorSpace {
   SRgb,

--- a/rs/src/image.rs
+++ b/rs/src/image.rs
@@ -6,7 +6,7 @@ use ::serde::{Deserialize, Serialize};
 ///   `DefineJpegTables` tag and injected in the first Start Of Frame (SOF) JPEG chunk.
 /// - `x-ajpeg`: JPEG with alpha mask (see DefineJPEG3):
 ///   `x-ajpeg` :: `jpeg_size(uint16be)` `jpeg` `alpha`
-#[derive(Serialize, Deserialize, Debug, PartialEq, Eq)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Copy, Clone)]
 pub enum ImageType {
   #[serde(rename = "image/jpeg")]
   Jpeg,

--- a/rs/src/lib.rs
+++ b/rs/src/lib.rs
@@ -70,7 +70,7 @@ mod shape;
 
 mod sound;
 
-#[derive(Serialize, Deserialize, Debug, PartialEq, Eq)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Copy, Clone)]
 #[serde(rename_all = "kebab-case")]
 pub enum BlendMode {
   Normal,

--- a/rs/src/movie.rs
+++ b/rs/src/movie.rs
@@ -4,7 +4,7 @@ use crate::basic_types::Rect;
 use crate::fixed::Ufixed8P8;
 use crate::Tag;
 
-#[derive(Serialize, Deserialize, Debug, PartialEq, Eq)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Copy, Clone)]
 #[serde(rename_all = "kebab-case")]
 pub enum CompressionMethod {
   None,

--- a/rs/src/shape.rs
+++ b/rs/src/shape.rs
@@ -4,7 +4,7 @@ use crate::fill_styles;
 use crate::helpers::{buffer_to_hex, hex_to_buffer};
 use crate::join_styles;
 
-#[derive(Serialize, Deserialize, Debug, PartialEq, Eq)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Copy, Clone)]
 #[serde(rename_all = "kebab-case")]
 pub enum CapStyle {
   None,

--- a/rs/src/sound.rs
+++ b/rs/src/sound.rs
@@ -1,6 +1,6 @@
 use ::serde::{Deserialize, Serialize};
 
-#[derive(Serialize, Deserialize, Debug, PartialEq, Eq)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Copy, Clone)]
 #[serde(rename_all = "kebab-case")]
 pub enum AudioCodingFormat {
   UncompressedNativeEndian,
@@ -13,7 +13,7 @@ pub enum AudioCodingFormat {
   Speex,
 }
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq, Copy, Clone)]
 pub enum SoundRate {
   SoundRate5500,
   SoundRate11000,
@@ -69,7 +69,7 @@ impl<'de> ::serde::Deserialize<'de> for SoundRate {
   }
 }
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq, Copy, Clone)]
 pub enum SoundSize {
   SoundSize8,
   SoundSize16,
@@ -120,7 +120,7 @@ impl<'de> ::serde::Deserialize<'de> for SoundSize {
   }
 }
 
-#[derive(Serialize, Deserialize, Debug, PartialEq, Eq)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Copy, Clone)]
 #[serde(rename_all = "kebab-case")]
 pub enum SoundType {
   Mono,

--- a/rs/src/text.rs
+++ b/rs/src/text.rs
@@ -3,7 +3,7 @@ use ::serde::{Deserialize, Serialize};
 use super::basic_types::{Rect, StraightSRgba8};
 use super::float_is::Is;
 
-#[derive(Serialize, Deserialize, Debug, PartialEq, Eq)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Copy, Clone)]
 #[serde(rename_all = "kebab-case")]
 pub enum CsmTableHint {
   Thin,
@@ -57,7 +57,7 @@ pub struct GlyphEntry {
   pub advance: i32,
 }
 
-#[derive(Serialize, Deserialize, Debug, PartialEq, Eq)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Copy, Clone)]
 #[serde(rename_all = "kebab-case")]
 pub enum GridFitting {
   None,
@@ -73,7 +73,7 @@ pub struct KerningRecord {
   pub adjustment: i16,
 }
 
-#[derive(Serialize, Deserialize, Debug, PartialEq, Eq)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Copy, Clone)]
 #[serde(rename_all = "kebab-case")]
 pub enum TextAlignment {
   Left,
@@ -96,7 +96,7 @@ pub struct TextRecord {
   pub entries: Vec<GlyphEntry>,
 }
 
-#[derive(Serialize, Deserialize, Debug, PartialEq, Eq)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Copy, Clone)]
 #[serde(rename_all = "kebab-case")]
 pub enum TextRenderer {
   Normal,


### PR DESCRIPTION
This commit adds the `Copy` trait to enums without data. This improves ergonomics when passing values of this type as function parameters: you can now pass them by value instead of by reference.