### PR TITLE
[all] Define `ScriptLimits` tag

### DIFF
--- a/docs/tags/script-limits.md
+++ b/docs/tags/script-limits.md
@@ -1,0 +1,11 @@
+# ScriptLimits
+
+```
+interface ScriptLimits variantof Tag(type) {
+  maxRecursionDepth: Uint(16);
+  scriptTimeout: Uint(16);
+}
+```
+
+- `maxRecursionDepth` has a default of 256.
+- `scriptTimeout` is in seconds. Default is between 15 and 20 seconds.

--- a/rs/src/lib.rs
+++ b/rs/src/lib.rs
@@ -1,5 +1,4 @@
 use ::serde::{Deserialize, Serialize};
-
 pub use ::swf_fixed as fixed;
 
 pub use crate::basic_types::ColorTransform;
@@ -133,6 +132,7 @@ pub enum Tag {
   Metadata(tags::Metadata),
   PlaceObject(tags::PlaceObject),
   RemoveObject(tags::RemoveObject),
+  ScriptLimits(tags::ScriptLimits),
   SetBackgroundColor(tags::SetBackgroundColor),
   ShowFrame,
   SoundStreamBlock(tags::SoundStreamBlock),

--- a/rs/src/tags.rs
+++ b/rs/src/tags.rs
@@ -369,6 +369,13 @@ pub struct RemoveObject {
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
+pub struct ScriptLimits {
+  pub max_recursion_depth: u16,
+  pub script_timeout: u16,
+}
+
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
 pub struct SetBackgroundColor {
   /// Color of the display background
   pub color: SRgb8,

--- a/ts/src/lib/tags/script-limits.ts
+++ b/ts/src/lib/tags/script-limits.ts
@@ -1,0 +1,25 @@
+import { $Uint16 } from "kryo/builtins/uint16";
+import { CaseStyle } from "kryo/case-style";
+import { DocumentIoType, DocumentType } from "kryo/types/document";
+import { LiteralType } from "kryo/types/literal";
+import { Uint16 } from "semantic-types";
+import { _Tag } from "./_tag";
+import { $TagType, TagType } from "./_type";
+
+export interface ScriptLimits extends _Tag {
+  readonly type: TagType.ScriptLimits;
+  readonly maxRecursionDepth: Uint16;
+  /**
+   * In seconds
+   */
+  readonly scriptTimeout: Uint16;
+}
+
+export const $ScriptLimits: DocumentIoType<ScriptLimits> = new DocumentType<ScriptLimits>({
+  properties: {
+    type: {type: new LiteralType({type: $TagType, value: TagType.ScriptLimits as TagType.ScriptLimits})},
+    maxRecursionDepth: {type: $Uint16},
+    scriptTimeout: {type: $Uint16},
+  },
+  changeCase: CaseStyle.SnakeCase,
+});


### PR DESCRIPTION
This commit adds the `ScriptLimits` tag (code 65). Compared to the spec, `scriptTimeoutSeconds` is renamed to `scriptTimeout`.