### PR TITLE
[all] Define `SymbolClass` tag

### DIFF
--- a/docs/tags/symbol-class.md
+++ b/docs/tags/symbol-class.md
@@ -1,0 +1,9 @@
+# SymbolClass
+
+```
+interface SymbolClass variantof Tag(type) {
+  symbols: NamedId[];
+}
+```
+
+`ExportAssets` for AS3.

--- a/rs/src/lib.rs
+++ b/rs/src/lib.rs
@@ -138,6 +138,7 @@ pub enum Tag {
   ShowFrame,
   SoundStreamBlock(tags::SoundStreamBlock),
   SoundStreamHead(tags::SoundStreamHead),
+  SymbolClass(tags::SymbolClass),
   Telemetry(tags::Telemetry),
   Unknown(tags::Unknown),
 }

--- a/rs/src/tags.rs
+++ b/rs/src/tags.rs
@@ -416,6 +416,12 @@ pub struct SoundStreamHead {
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
+pub struct SymbolClass {
+  pub symbols: Vec<NamedId>,
+}
+
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
 pub struct Telemetry {
   // TODO(demurgos): Serialize optional buffers to hex
   // #[serde(serialize_with = "buffer_to_hex", deserialize_with = "hex_to_buffer")]

--- a/ts/src/lib/tag.ts
+++ b/ts/src/lib/tag.ts
@@ -36,6 +36,7 @@ export type Tag =
   | tags.ShowFrame
   | tags.SoundStreamBlock
   | tags.SoundStreamHead
+  | tags.SymbolClass
   | tags.Telemetry
   | tags.Unknown;
 
@@ -75,6 +76,7 @@ export const $Tag: TaggedUnionType<Tag> = new TaggedUnionType<Tag>(() => ({
     tags.$ShowFrame,
     tags.$SoundStreamBlock,
     tags.$SoundStreamHead,
+    tags.$SymbolClass,
     tags.$Telemetry,
     tags.$Unknown,
   ],

--- a/ts/src/lib/tags/index.ts
+++ b/ts/src/lib/tags/index.ts
@@ -32,5 +32,6 @@ export { $SetBackgroundColor, SetBackgroundColor } from "./set-background-color"
 export { $ShowFrame, ShowFrame } from "./show-frame";
 export { $SoundStreamBlock, SoundStreamBlock } from "./sound-stream-block";
 export { $SoundStreamHead, SoundStreamHead } from "./sound-stream-head";
+export { $SymbolClass, SymbolClass } from "./symbol-class";
 export { $Telemetry, Telemetry } from "./telemetry";
 export { $Unknown, Unknown } from "./unknown";

--- a/ts/src/lib/tags/symbol-class.ts
+++ b/ts/src/lib/tags/symbol-class.ts
@@ -1,0 +1,20 @@
+import { CaseStyle } from "kryo/case-style";
+import { ArrayType } from "kryo/types/array";
+import { DocumentIoType, DocumentType } from "kryo/types/document";
+import { LiteralType } from "kryo/types/literal";
+import { $NamedId, NamedId } from "../named-id";
+import { _Tag } from "./_tag";
+import { $TagType, TagType } from "./_type";
+
+export interface SymbolClass extends _Tag {
+  readonly type: TagType.SymbolClass;
+  readonly symbols: ReadonlyArray<NamedId>;
+}
+
+export const $SymbolClass: DocumentIoType<SymbolClass> = new DocumentType<SymbolClass>({
+  properties: {
+    type: {type: new LiteralType({type: $TagType, value: TagType.SymbolClass as TagType.SymbolClass})},
+    symbols: {type: new ArrayType({itemType: $NamedId, maxLength: Infinity})},
+  },
+  changeCase: CaseStyle.SnakeCase,
+});


### PR DESCRIPTION
This commit adds the `SymbolClass` tag (code 76).