### PR TITLE
[all] Define `StartSound` and `StartSound2` tags

### DIFF
--- a/docs/tags/start-sound.md
+++ b/docs/tags/start-sound.md
@@ -1,0 +1,8 @@
+# StartSound
+
+```
+interface StartSound variantof Tag(type) {
+  soundId: Uint(16);
+  soundInfo: SoundInfo;
+}
+```

--- a/docs/tags/start-sound2.md
+++ b/docs/tags/start-sound2.md
@@ -1,0 +1,8 @@
+# StartSound
+
+```
+interface StartSound2 variantof Tag(type) {
+  soundClassName: String;
+  soundInfo: SoundInfo;
+}
+```

--- a/rs/src/lib.rs
+++ b/rs/src/lib.rs
@@ -138,6 +138,8 @@ pub enum Tag {
   ShowFrame,
   SoundStreamBlock(tags::SoundStreamBlock),
   SoundStreamHead(tags::SoundStreamHead),
+  StartSound(tags::StartSound),
+  StartSound2(tags::StartSound2),
   SymbolClass(tags::SymbolClass),
   Telemetry(tags::Telemetry),
   Unknown(tags::Unknown),

--- a/rs/src/sound.rs
+++ b/rs/src/sound.rs
@@ -126,3 +126,27 @@ pub enum SoundType {
   Mono,
   Stereo,
 }
+
+
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub struct SoundInfo {
+  pub sync_stop: bool,
+  pub sync_no_multiple: bool,
+  #[serde(skip_serializing_if = "Option::is_none")]
+  pub in_point: Option<u32>,
+  #[serde(skip_serializing_if = "Option::is_none")]
+  pub out_point: Option<u32>,
+  #[serde(skip_serializing_if = "Option::is_none")]
+  pub loop_count: Option<u16>,
+  #[serde(skip_serializing_if = "Option::is_none")]
+  pub envelope_records: Option<Vec<SoundEnvelope>>,
+}
+
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub struct SoundEnvelope {
+  pub pos44: u32,
+  pub left_level: u16,
+  pub right_level: u16,
+}

--- a/rs/src/tags.rs
+++ b/rs/src/tags.rs
@@ -1,6 +1,5 @@
 use ::serde::{Deserialize, Serialize};
 
-use crate::AudioCodingFormat;
 use crate::basic_types::{ColorTransformWithAlpha, LanguageCode, Matrix, NamedId, Rect, SRgb8, StraightSRgba8};
 use crate::BlendMode;
 use crate::button::ButtonCondAction;
@@ -11,10 +10,7 @@ use crate::helpers::{buffer_to_hex, hex_to_buffer};
 use crate::ImageType;
 use crate::shape::{ClipAction, Glyph, Shape};
 use crate::shape::MorphShape;
-use crate::sound;
-use crate::SoundRate;
-use crate::SoundSize;
-use crate::SoundType;
+use crate::sound::{AudioCodingFormat, SoundInfo, SoundRate, SoundSize, SoundType};
 use crate::Tag;
 use crate::text::{CsmTableHint, FontAlignmentZone, FontLayout, GridFitting, TextAlignment, TextRecord, TextRenderer};
 
@@ -402,16 +398,30 @@ pub struct SoundStreamBlock {
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub struct SoundStreamHead {
-  pub playback_sound_type: sound::SoundType,
-  pub playback_sound_size: sound::SoundSize,
-  pub playback_sound_rate: sound::SoundRate,
-  pub stream_sound_type: sound::SoundType,
-  pub stream_sound_size: sound::SoundSize,
-  pub stream_sound_rate: sound::SoundRate,
-  pub stream_format: sound::AudioCodingFormat,
+  pub playback_sound_type: SoundType,
+  pub playback_sound_size: SoundSize,
+  pub playback_sound_rate: SoundRate,
+  pub stream_sound_type: SoundType,
+  pub stream_sound_size: SoundSize,
+  pub stream_sound_rate: SoundRate,
+  pub stream_format: AudioCodingFormat,
   pub stream_sample_count: u16,
   #[serde(skip_serializing_if = "Option::is_none")]
   pub latency_seek: Option<i16>,
+}
+
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub struct StartSound {
+  pub sound_id: u16,
+  pub sound_info: SoundInfo,
+}
+
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub struct StartSound2 {
+  pub sound_class_name: String,
+  pub sound_info: SoundInfo,
 }
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq)]

--- a/ts/src/lib/sound/sound-info.ts
+++ b/ts/src/lib/sound/sound-info.ts
@@ -1,9 +1,10 @@
 import { $Boolean } from "kryo/builtins/boolean";
+import { $Uint16 } from "kryo/builtins/uint16";
+import { $Uint32 } from "kryo/builtins/uint32";
 import { CaseStyle } from "kryo/case-style";
 import { ArrayType } from "kryo/types/array";
 import { DocumentIoType, DocumentType } from "kryo/types/document";
-import { IntegerType } from "kryo/types/integer";
-import { Uint32 } from "semantic-types";
+import { Uint16, Uint32 } from "semantic-types";
 import { $SoundEnvelope, SoundEnvelope } from "./sound-envelope";
 
 export interface SoundInfo {
@@ -11,6 +12,7 @@ export interface SoundInfo {
   syncNoMultiple: boolean;
   inPoint?: Uint32;
   outPoint?: Uint32;
+  loopCount?: Uint16;
   envelopeRecords?: SoundEnvelope[];
 }
 
@@ -18,8 +20,9 @@ export const $SoundInfo: DocumentIoType<SoundInfo> = new DocumentType<SoundInfo>
   properties: {
     syncStop: {type: $Boolean},
     syncNoMultiple: {type: $Boolean},
-    inPoint: {type: new IntegerType(), optional: true},
-    outPoint: {type: new IntegerType(), optional: true},
+    inPoint: {type: $Uint32, optional: true},
+    outPoint: {type: $Uint32, optional: true},
+    loopCount: {type: $Uint16, optional: true},
     envelopeRecords: {type: new ArrayType({itemType: $SoundEnvelope, maxLength: Infinity}), optional: true},
   },
   changeCase: CaseStyle.SnakeCase,

--- a/ts/src/lib/sprite-tag.ts
+++ b/ts/src/lib/sprite-tag.ts
@@ -11,6 +11,8 @@ export type SpriteTag =
   | tags.ShowFrame
   | tags.SoundStreamHead
   | tags.SoundStreamBlock
+  | tags.StartSound
+  | tags.StartSound2
   | tags.Unknown;
 
 export const $SpriteTag: TaggedUnionType<SpriteTag> = new TaggedUnionType<SpriteTag>(() => ({
@@ -24,6 +26,8 @@ export const $SpriteTag: TaggedUnionType<SpriteTag> = new TaggedUnionType<Sprite
     tags.$ShowFrame,
     tags.$SoundStreamBlock,
     tags.$SoundStreamHead,
+    tags.$StartSound,
+    tags.$StartSound2,
     tags.$Unknown,
   ],
   tag: "type",

--- a/ts/src/lib/tag.ts
+++ b/ts/src/lib/tag.ts
@@ -36,6 +36,8 @@ export type Tag =
   | tags.ShowFrame
   | tags.SoundStreamBlock
   | tags.SoundStreamHead
+  | tags.StartSound
+  | tags.StartSound2
   | tags.SymbolClass
   | tags.Telemetry
   | tags.Unknown;
@@ -76,6 +78,8 @@ export const $Tag: TaggedUnionType<Tag> = new TaggedUnionType<Tag>(() => ({
     tags.$ShowFrame,
     tags.$SoundStreamBlock,
     tags.$SoundStreamHead,
+    tags.$StartSound,
+    tags.$StartSound2,
     tags.$SymbolClass,
     tags.$Telemetry,
     tags.$Unknown,

--- a/ts/src/lib/tags/index.ts
+++ b/ts/src/lib/tags/index.ts
@@ -32,6 +32,8 @@ export { $SetBackgroundColor, SetBackgroundColor } from "./set-background-color"
 export { $ShowFrame, ShowFrame } from "./show-frame";
 export { $SoundStreamBlock, SoundStreamBlock } from "./sound-stream-block";
 export { $SoundStreamHead, SoundStreamHead } from "./sound-stream-head";
+export { $StartSound, StartSound } from "./start-sound";
+export { $StartSound2, StartSound2 } from "./start-sound2";
 export { $SymbolClass, SymbolClass } from "./symbol-class";
 export { $Telemetry, Telemetry } from "./telemetry";
 export { $Unknown, Unknown } from "./unknown";

--- a/ts/src/lib/tags/start-sound.ts
+++ b/ts/src/lib/tags/start-sound.ts
@@ -3,9 +3,9 @@ import { CaseStyle } from "kryo/case-style";
 import { DocumentIoType, DocumentType } from "kryo/types/document";
 import { LiteralType } from "kryo/types/literal";
 import { Uint16 } from "semantic-types";
-import { _Tag } from "../tags/_tag";
-import { $TagType, TagType } from "../tags/_type";
-import { $SoundInfo, SoundInfo } from "./sound-info";
+import { $SoundInfo, SoundInfo } from "../sound/sound-info";
+import { _Tag } from "./_tag";
+import { $TagType, TagType } from "./_type";
 
 export interface StartSound extends _Tag {
   type: TagType.StartSound;

--- a/ts/src/lib/tags/start-sound2.ts
+++ b/ts/src/lib/tags/start-sound2.ts
@@ -2,9 +2,9 @@ import { CaseStyle } from "kryo/case-style";
 import { DocumentIoType, DocumentType } from "kryo/types/document";
 import { LiteralType } from "kryo/types/literal";
 import { Ucs2StringType } from "kryo/types/ucs2-string";
-import { _Tag } from "../tags/_tag";
-import { $TagType, TagType } from "../tags/_type";
-import { $SoundInfo, SoundInfo } from "./sound-info";
+import { $SoundInfo, SoundInfo } from "../sound/sound-info";
+import { _Tag } from "./_tag";
+import { $TagType, TagType } from "./_type";
 
 export interface StartSound2 extends _Tag {
   type: TagType.StartSound2;


### PR DESCRIPTION
This commit adds the `StartSound` tag (code 15) and `StartSound2` tag (code 89).