### PR TITLE
[rs] Skip `control_delta` serialization if `None`

### DIFF
--- a/rs/src/shape.rs
+++ b/rs/src/shape.rs
@@ -165,6 +165,7 @@ pub mod shape_records {
 
     /// Difference between the edge start and quadratic bezier control point (if
     /// any).
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub control_delta: Option<Vector2D>,
   }
 
@@ -180,10 +181,12 @@ pub mod shape_records {
 
     /// Difference between the edge start and quadratic bezier control point (if
     /// any) in the start-state of the morph shape.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub control_delta: Option<Vector2D>,
 
     /// Difference between the edge start and quadratic bezier control point (if
     /// any) in the end-state of the morph shape.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub morph_control_delta: Option<Vector2D>,
   }
 


### PR DESCRIPTION
This commit ensures that `control_delta` and `morph_control_delta` are not serialized when `None`. The old behavior (writing `null`) was inconsistent with the other Rust types and the Typescript implementation.