### PR TITLE
[all] Define `TagHeader`

### DIFF
--- a/docs/tag-header.md
+++ b/docs/tag-header.md
@@ -1,0 +1,10 @@
+# TagHeader
+
+Internal type representing a raw tag header.
+
+```
+interface TagHeader {
+  code: Uint(16);
+  length: Uint(32);
+}
+```

--- a/rs/src/lib.rs
+++ b/rs/src/lib.rs
@@ -103,6 +103,13 @@ pub enum Filter {
   GradientGlow(filters::GradientGlow),
 }
 
+#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub struct TagHeader {
+  pub code: u16,
+  pub length: u32,
+}
+
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(tag = "type", rename_all = "kebab-case")]
 pub enum Tag {

--- a/ts/src/lib/tag-header.ts
+++ b/ts/src/lib/tag-header.ts
@@ -1,0 +1,18 @@
+import { $Uint16 } from "kryo/builtins/uint16";
+import { $Uint32 } from "kryo/builtins/uint32";
+import { CaseStyle } from "kryo/case-style";
+import { DocumentIoType, DocumentType } from "kryo/types/document";
+import { Uint16, Uint32 } from "semantic-types";
+
+export interface TagHeader {
+  code: Uint16;
+  length: Uint32;
+}
+
+export const $TagHeader: DocumentIoType<TagHeader> = new DocumentType<TagHeader>({
+  properties: {
+    code: {type: $Uint16},
+    length: {type: $Uint32},
+  },
+  changeCase: CaseStyle.SnakeCase,
+});


### PR DESCRIPTION
`TagHeader` is an internal type representing a raw tag header.

It is mainly intended for parsers and emitters.