### PR TITLE
[all] Release v0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Next
+# v0.6.0 (2019-04-22)
 
 - **[Breaking change]** Update to MIT/Apache2 license.
 - **[Feature]** Define `TagHeader`.

--- a/rs/Cargo.lock
+++ b/rs/Cargo.lock
@@ -85,7 +85,7 @@ dependencies = [
 
 [[package]]
 name = "swf-tree"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -99,7 +99,7 @@ name = "swf-tree-bin"
 version = "0.5.0"
 dependencies = [
  "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
- "swf-tree 0.5.0",
+ "swf-tree 0.6.0",
 ]
 
 [[package]]

--- a/rs/Cargo.toml
+++ b/rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "swf-tree"
-version = "0.5.0"
+version = "0.6.0"
 authors = ["Charles Samborski <demurgos@demurgos.net>"]
 description = "Abstract Syntax Tree (AST) for SWF files"
 documentation = "https://github.com/open-flash/swf-tree"

--- a/ts/package.json
+++ b/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "swf-tree",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "homepage": "https://github.com/open-flash/swf-tree",
   "description": "Abstract Syntax Tree for SWF",
   "main": "dist/lib/index.js",


### PR DESCRIPTION
- **[Breaking change]** Update to MIT/Apache2 license.
- **[Feature]** Define `TagHeader`.
- **[Internal]** Refactor test samples organization.
- **[Internal]** Add `CHANGELOG.md`.

---

- Rust
  - **[Fix]** Skip `control_delta` serialization when `None`.
  - **[Fix]** Remove binary-only dependencies from published crate.
  - **[Fix]** Update to `swf-fixed@0.1.4`.

---

- Typescript
  - **[Breaking change]** Rename `ClipActions` to `ClipAction` ([#26](https://github.com/open-flash/swf-tree/issues/26)).