### PR TITLE
[all] Reformat `CHANGELOG.md`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,55 +1,50 @@
-# v0.6.0 (2019-04-22)
+# 0.6.0 (2019-04-22)
 
 - **[Breaking change]** Update to MIT/Apache2 license.
 - **[Feature]** Define `TagHeader`.
 - **[Internal]** Refactor test samples organization.
 - **[Internal]** Add `CHANGELOG.md`.
 
+### Rust
 
-- Rust
-  - **[Fix]** Skip `control_delta` serialization when `None`.
-  - **[Fix]** Remove binary-only dependencies from published crate.
-  - **[Fix]** Update to `swf-fixed@0.1.4`.
+- **[Fix]** Skip `control_delta` serialization when `None`.
+- **[Fix]** Remove binary-only dependencies from published crate.
+- **[Fix]** Update to `swf-fixed@0.1.4`.
 
+### Typescript
 
-- Typescript
-  - **[Breaking change]** Rename `ClipActions` to `ClipAction` ([#26](https://github.com/open-flash/swf-tree/issues/26)).
+- **[Breaking change]** Rename `ClipActions` to `ClipAction` ([#26](https://github.com/open-flash/swf-tree/issues/26)).
 
-
-# v0.5.0 (2019-04-13)
+# 0.5.0 (2019-04-13)
 
 - **[Breaking change]** Unify `StraightEdge` and `CurvedEdge` into `Edge` as well as their morph counterparts. ([#22](https://github.com/open-flash/swf-tree/issues/22)).
 
+# 0.4.2 (2019-04-05)
 
-# v0.4.2 (2019-04-05)
+### Rust
 
-- Rust
-  - **[Feature]** Derive the following traits when applicable: `Copy`, `Clone`, `PartialOrd`, `Ord` and `Hash`.
-  - **[Feature]** Implement `Default` for matrices.
-  - **[Fix]** Update to `swf-fixed@0.1.3`.
+- **[Feature]** Derive the following traits when applicable: `Copy`, `Clone`, `PartialOrd`, `Ord` and `Hash`.
+- **[Feature]** Implement `Default` for matrices.
+- **[Fix]** Update to `swf-fixed@0.1.3`.
 
+# 0.4.1 (2019-03-30)
 
-# v0.4.1 (2019-03-30)
+### Rust
 
-- Rust
-  - **[Fix]** Export `SoundEnvelope` and `SoundInfo`
-  - **[Fix]** Update dependencies
+- **[Fix]** Export `SoundEnvelope` and `SoundInfo`
+- **[Fix]** Update dependencies
 
-
-# v0.4.0 (2019-03-29)
+# 0.4.0 (2019-03-29)
 
 - **[Feature]** Add definitions for the following tags: `DoAbc`, `ScriptLimits`, `StartSound`, `StartSound2` and `SymbolClass`
 
+### Rust
+- **[Feature]** Derive `Copy` trait for simple enums
 
-- Rust
-  - **[Feature]** Derive `Copy` trait for simple enums
-
-
-# v0.3.2 (2019-03-28)
+# 0.3.2 (2019-03-28)
 
 - **[Breaking change]** Refactor sound tags: reorder fields and rename `streamSoundSampleCount` to `streamSampleCount` and `streamSoundCompression` to `streamFormat`.
 
-
-# v0.2.1 (2019-03-28)
+# 0.2.1 (2019-03-28)
 
 - **[Fix]** Use `Sint32` for `Rect` dimensions


### PR DESCRIPTION
Remove `v` prefix. Use sub-headers instead of nested lists for implementation-specific changes.