### PR TITLE
[all] Update `ButtonCond` field order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - **[Breaking change]** Add `em_square_size` field to `DefineFont` ([#42](https://github.com/open-flash/swf-tree/issues/42)).
 - **[Fix]** Update `ButtonCond` field order.
+- **[Fix]** Update `ButtonRecord` field order.
 - **[Internal]** Update test samples.
 
 ### Typescript

--- a/rs/src/button.rs
+++ b/rs/src/button.rs
@@ -34,14 +34,14 @@ pub struct ButtonCondAction {
 #[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub struct ButtonCond {
-  pub idle_to_over_down: bool,
-  pub out_down_to_idle: bool,
-  pub out_down_to_over_down: bool,
-  pub over_down_to_out_down: bool,
-  pub over_down_to_over_up: bool,
-  pub over_up_to_over_down: bool,
-  pub over_up_to_idle: bool,
   pub idle_to_over_up: bool,
+  pub over_up_to_idle: bool,
+  pub over_up_to_over_down: bool,
+  pub over_down_to_over_up: bool,
+  pub over_down_to_out_down: bool,
+  pub out_down_to_over_down: bool,
+  pub out_down_to_idle: bool,
+  pub idle_to_over_down: bool,
   pub over_down_to_idle: bool,
   #[serde(skip_serializing_if = "Option::is_none")]
   pub key_press: Option<u32>,

--- a/ts/src/lib/button/button-cond.ts
+++ b/ts/src/lib/button/button-cond.ts
@@ -5,28 +5,28 @@ import { DocumentIoType, DocumentType } from "kryo/types/document";
 import { Uint32 } from "semantic-types";
 
 export interface ButtonCond {
-  idleToOverDown: boolean;
-  outDownToIdle: boolean;
-  outDownToOverDown: boolean;
-  overDownToOutDown: boolean;
-  overDownToOverUp: boolean;
-  overUpToOverDown: boolean;
-  overUpToIdle: boolean;
   idleToOverUp: boolean;
+  overUpToIdle: boolean;
+  overUpToOverDown: boolean;
+  overDownToOverUp: boolean;
+  overDownToOutDown: boolean;
+  outDownToOverDown: boolean;
+  outDownToIdle: boolean;
+  idleToOverDown: boolean;
   overDownToIdle: boolean;
   keyPress?: Uint32;
 }
 
 export const $ButtonCond: DocumentIoType<ButtonCond> = new DocumentType<ButtonCond>({
   properties: {
-    idleToOverDown: {type: $Boolean},
-    outDownToIdle: {type: $Boolean},
-    outDownToOverDown: {type: $Boolean},
-    overDownToOutDown: {type: $Boolean},
-    overDownToOverUp: {type: $Boolean},
-    overUpToOverDown: {type: $Boolean},
-    overUpToIdle: {type: $Boolean},
     idleToOverUp: {type: $Boolean},
+    overUpToIdle: {type: $Boolean},
+    overUpToOverDown: {type: $Boolean},
+    overDownToOverUp: {type: $Boolean},
+    overDownToOutDown: {type: $Boolean},
+    outDownToOverDown: {type: $Boolean},
+    outDownToIdle: {type: $Boolean},
+    idleToOverDown: {type: $Boolean},
     overDownToIdle: {type: $Boolean},
     keyPress: {type: $Uint32, optional: true},
   },


### PR DESCRIPTION
This commit updates the `ButtonCond` field order to match the order in which they are encoded.