### PR TITLE
[all] Release v0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Next
+# 0.7.0 (2019-05-21)
 
 - **[Breaking change]** Add `em_square_size` field to `DefineFont` ([#42](https://github.com/open-flash/swf-tree/issues/42)).
 - **[Breaking change]** Require `align` to be defined in `DefineDynamicText` ([#41](https://github.com/open-flash/swf-tree/issues/41)).

--- a/rs/Cargo.lock
+++ b/rs/Cargo.lock
@@ -85,7 +85,7 @@ dependencies = [
 
 [[package]]
 name = "swf-tree"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -99,7 +99,7 @@ name = "swf-tree-bin"
 version = "0.5.0"
 dependencies = [
  "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
- "swf-tree 0.6.0",
+ "swf-tree 0.7.0",
 ]
 
 [[package]]

--- a/rs/Cargo.toml
+++ b/rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "swf-tree"
-version = "0.6.0"
+version = "0.7.0"
 authors = ["Charles Samborski <demurgos@demurgos.net>"]
 description = "Abstract Syntax Tree (AST) for SWF files"
 documentation = "https://github.com/open-flash/swf-tree"

--- a/ts/package.json
+++ b/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "swf-tree",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "homepage": "https://github.com/open-flash/swf-tree",
   "description": "Abstract Syntax Tree for SWF",
   "main": "dist/lib/index.js",


### PR DESCRIPTION
- **[Breaking change]** Add `em_square_size` field to `DefineFont` ([#42](https://github.com/open-flash/swf-tree/issues/42)).
- **[Breaking change]** Require `align` to be defined in `DefineDynamicText` ([#41](https://github.com/open-flash/swf-tree/issues/41)).
- **[Fix]** Update `ButtonCond` field order.
- **[Fix]** Update `ButtonRecord` field order.
- **[Internal]** Update test samples.

### Typescript

- **[Internal]** Update build tools.