### PR TITLE
[rs] Use `[f32; 20]` in `ColorMatrix` filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@
 - **[Breaking change]** Remove `DefinePartialFont` tag (replaced by `DefineGlyphFont`).
 - **[Internal]** Update `README.md`.
 
+## Rust
+
+- **[Breaking change]** Use `[f32; 20]` in `ColorMatrix` filter ([#25](https://github.com/open-flash/swf-tree/issues/25)).
+- **[Fix]** Fix `Is` implementation for vectors (used to compare floats by bit pattern).
+
 # 0.7.2 (2019-07-05)
 
 - **[Feature]** Define `DefineGlyphFont` tag.

--- a/rs/src/filters.rs
+++ b/rs/src/filters.rs
@@ -33,7 +33,7 @@ pub struct Bevel {
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub struct ColorMatrix {
-  pub matrix: Vec<f32>,
+  pub matrix: [f32; 20],
 }
 
 impl ::std::cmp::PartialEq for ColorMatrix {

--- a/rs/src/float_is.rs
+++ b/rs/src/float_is.rs
@@ -23,6 +23,22 @@ impl<T: Is> Is for Vec<T> {
     if self.len() != other.len() {
       return false;
     }
+    for (i, left) in self.iter().enumerate() {
+      if !left.is(&other[i]) {
+        return false;
+      }
+    }
+    true
+  }
+}
+
+impl Is for [f32;20] {
+  fn is(&self, other: &Self) -> bool {
+    for i in 0..20 {
+      if !self[i].is(&other[i]) {
+        return false
+      }
+    }
     true
   }
 }


### PR DESCRIPTION
Also fix a bug in the `Is` implementation for vectors.

Closes open-flash/swf-tree#25