### PR TITLE
[all] Release v0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Next
+# 0.8.0 (2019-07-08)
 
 - **[Breaking change]** Require `language` to be defined in `DefineFontInfo`.
 - **[Breaking change]** Reorder `FileAttributes` fields.

--- a/rs/Cargo.lock
+++ b/rs/Cargo.lock
@@ -85,7 +85,7 @@ dependencies = [
 
 [[package]]
 name = "swf-tree"
-version = "0.7.2"
+version = "0.8.0"
 dependencies = [
  "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -99,7 +99,7 @@ name = "swf-tree-bin"
 version = "0.5.0"
 dependencies = [
  "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
- "swf-tree 0.7.2",
+ "swf-tree 0.8.0",
 ]
 
 [[package]]

--- a/rs/Cargo.toml
+++ b/rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "swf-tree"
-version = "0.7.2"
+version = "0.8.0"
 authors = ["Charles Samborski <demurgos@demurgos.net>"]
 description = "Abstract Syntax Tree (AST) for SWF files"
 documentation = "https://github.com/open-flash/swf-tree"

--- a/ts/package.json
+++ b/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "swf-tree",
-  "version": "0.7.2",
+  "version": "0.8.0",
   "homepage": "https://github.com/open-flash/swf-tree",
   "description": "Abstract Syntax Tree for SWF",
   "main": "dist/lib/index.js",


### PR DESCRIPTION
- **[Breaking change]** Require `language` to be defined in `DefineFontInfo`.
- **[Breaking change]** Reorder `FileAttributes` fields.
- **[Breaking change]** Remove `DefinePartialFont` tag (replaced by `DefineGlyphFont`).
- **[Internal]** Update `README.md`.

## Rust

- **[Breaking change]** Use `[f32; 20]` in `ColorMatrix` filter ([#25](https://github.com/open-flash/swf-tree/issues/25)).
- **[Fix]** Fix `Is` implementation for vectors (used to compare floats by bit pattern).
- **[Internal]** Add `rustfmt` support.