### PR TITLE
[rs] Expose `float_is` module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# Next
+
+## Rust
+
+- **[Fix]** Expose `float_is` module, to allow bit-pattern float equality.
+
 # 0.9.0 (2019-10-17)
 
 - **[Breaking change]** Change field order in `DefineMorphShape`.

--- a/rs/src/lib.rs
+++ b/rs/src/lib.rs
@@ -50,7 +50,7 @@ pub use crate::sound::SoundType;
 pub use crate::video::VideoCodec;
 pub use crate::video::VideoDeblocking;
 
-mod float_is;
+pub mod float_is;
 
 mod helpers;
 


### PR DESCRIPTION
This commit exposes the `float_is` module and its `Is` trait to allow bit-pattern float equality.