### PR TITLE
[ts] Fix pre-release npm tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 - **[Feature]** Make `serde` optional (enabled by default) ([#73](https://github.com/open-flash/swf-tree/issues/73)).
 - **[Fix]** Expose `float_is` module, to allow bit-pattern float equality.
 
+## Typescript
+
+- **[Fix]** Fix pre-release npm tag.
+
 # 0.9.0 (2019-10-17)
 
 - **[Breaking change]** Change field order in `DefineMorphShape`.

--- a/ts/gulpfile.ts
+++ b/ts/gulpfile.ts
@@ -42,7 +42,7 @@ const lib: LibTarget = {
       return <any> {...old, version, scripts: undefined, private: false};
     },
     npmPublish: {
-      tag: options.devDist !== undefined ? "next" : "latest",
+      tag: options.next !== undefined ? "next" : "latest",
     },
   },
   customTypingsDir: "src/custom-typings",


### PR DESCRIPTION
This commit fixes the pre-release npm tag. Instead of being published with the `next` tag, pre-releases used the default `latest` tag.